### PR TITLE
Should enable eslint to go with new .eslintrc file

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,6 +7,11 @@ engines:
         python:
           mass_threshold: 50
         javascript:
+  eslint:
+    enabled: true
+    channel: "eslint-3"
+    exclude_paths:
+    - "interface/Gruntfile.js"
   fixme:
     enabled: false
   radon:


### PR DESCRIPTION
I suggest these changes to .codeclimate.yml to enable eslint now that you've created the .eslintrc file.
